### PR TITLE
added readme for rails >= 3.0

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,7 +11,15 @@
 == Details
 - プロジェクト内のバージョンをカード形式で表示します。(The version in the project is displayed by the card format.)
 
-== Plugin Installation
+== Plugin Installation for Rails.version >= '3.0'
+- Download this plugin.
+- Unpack and move into RAILS_ROOT/plugins.
+- Restart Redmine.
+- Login and configure the plugin (Administration > Roles and permissions > Permissions report)
+- Configure the project (Project > Settings > Modules).
+- Click to Parking Lot Chart menu.
+
+== Plugin Installation for Rails.version < '3.0'
 - Download this plugin.
 - Unpack and move into RAILS_ROOT/vendor/plugins.
 - Rename the plugin directory to parking_lot_chart
@@ -19,6 +27,7 @@
 - Login and configure the plugin (Administration > Roles and permissions > Permissions report)
 - Configure the project (Project > Settings > Modules).
 - Click to Parking Lot Chart menu.
+
 
 == Note
 - This plugin works only Redmine 0.9.0 or higher.


### PR DESCRIPTION
README に Rails3 の場合の説明を付け加えました。
- プラグインのインストール先の変更
- フォルダをリネームすると動かなくなってしまう(コントローラが見つけられない)ので記載を削除
